### PR TITLE
Remove Unused References

### DIFF
--- a/Raven.Voron/Voron/Impl/FreeSpace/StreamBitArray.cs
+++ b/Raven.Voron/Voron/Impl/FreeSpace/StreamBitArray.cs
@@ -42,8 +42,6 @@ namespace Voron.Impl.FreeSpace
 {
     public sealed class StreamBitArray
     {
-        private static UTF8Encoding _defaultEncoding = new UTF8Encoding(true, false);
-
         readonly int[] _inner = new int[64];
 
         public int SetCount { get; private set; }


### PR DESCRIPTION
There's no need for Raven.Abstractions to have a dependency on Spatial4n.Core.NTS.
